### PR TITLE
Provide proximity hint for near guesses

### DIFF
--- a/number_guess.py
+++ b/number_guess.py
@@ -62,9 +62,12 @@ def provide_feedback(guess, target):
     else:
         return True
 
-    print(
-        f"{YELLOW}Warm!{RESET}" if abs(guess - target) <= 10 else f"{CYAN}Cold!{RESET}"
-    )
+    close = abs(guess - target) <= 10
+    if close:
+        direction = "higher" if guess < target else "lower"
+        print(f"{YELLOW}Hint: Try a bit {direction}!{RESET}")
+
+    print(f"{YELLOW}Warm!{RESET}" if close else f"{CYAN}Cold!{RESET}")
     return False
 
 


### PR DESCRIPTION
## Summary
- Give players a directional hint when their guess is within 10 of the target
- Retain existing warm/cold messaging alongside the new hint

## Testing
- `python -m py_compile number_guess.py`
- `python - <<'PY'
from number_guess import provide_feedback
print('Case 1: guess 45 target 50 (within 10, too low)')
provide_feedback(45, 50)
print('---')
print('Case 2: guess 95 target 100 (within 10, too low)')
provide_feedback(95,100)
print('---')
print('Case 3: guess 10 target 30 (far)')
provide_feedback(10,30)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6897cb0271bc832ba9d90851981996a0